### PR TITLE
[NO MERGE] Use cdelta instead of xdelta3

### DIFF
--- a/src/squashdelta.cxx
+++ b/src/squashdelta.cxx
@@ -586,10 +586,10 @@ int main(int argc, char* argv[])
 				if (dup2(patch_out.fd, 1) == -1)
 					throw IOError("Unable to override stdout via dup2()", errno);
 
-				if (execlp("xdelta3",
-						"xdelta3", "-v", "-9", "-S", "djw",
-						"-s", source_temp.name(), target_temp.name(),
-						static_cast<const char*>(0)) == -1)
+				if (execlp("cdelta",
+						   "cdelta", "--level", "7", "--stdout",
+						   "-s", source_temp.name(), "-t", target_temp.name(),
+						   static_cast<const char *>(0)) == -1)
 					throw IOError("execlp() failed", errno);
 			}
 			catch (IOError& e)


### PR DESCRIPTION
This changes the delta algorithm to cdelta instead of xdelta3. This is only a PoC, DON'T MERGE YET.

This should be augmented by adding a command-line flag to run `cdelta` instead of `xdelta3`. That way we can choose between the type of delta to use.