### PR TITLE
[TI-4422] Support files larger than 4 GiB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+
 Makefile
 Makefile.in
 

--- a/src/squashdelta.cxx
+++ b/src/squashdelta.cxx
@@ -33,17 +33,15 @@ extern "C"
 
 struct compressed_block
 {
-	// Host endianness
-	uint64_t offset;
-	uint32_t length;
-	uint32_t uncompressed_length;
+	size_t offset;
+	size_t length;
+	size_t uncompressed_length;
 	uint32_t hash;
 };
 
 #pragma pack(push, 1)
 struct serialized_compressed_block
 {
-	// Shall be big-endian
 	uint64_t offset;
 	uint32_t length;
 	uint32_t uncompressed_length;

--- a/src/squashdelta.cxx
+++ b/src/squashdelta.cxx
@@ -5,7 +5,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#	include "config.h"
+#include "config.h"
 #endif
 
 #include <iostream>
@@ -20,10 +20,10 @@
 
 extern "C"
 {
-#	include <sys/types.h>
-#	include <sys/wait.h>
-#	include <unistd.h>
-#	include <arpa/inet.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <arpa/inet.h>
 }
 
 #include "compressor.hxx"
@@ -42,7 +42,7 @@ struct compressed_block
 #pragma pack(push, 1)
 struct serialized_compressed_block
 {
-	uint32_t offset;
+	uint64_t offset;
 	uint32_t length;
 	uint32_t uncompressed_length;
 };
@@ -56,31 +56,32 @@ struct sqdelta_header
 };
 #pragma pack(pop)
 
+#define htonl(val) val
+
 const uint32_t sqdelta_magic = 0x5371ceb4;
 
-bool sort_by_offset(const struct compressed_block& lhs,
-		const struct compressed_block& rhs)
+bool sort_by_offset(const struct compressed_block &lhs,
+					const struct compressed_block &rhs)
 {
 	return lhs.offset < rhs.offset;
 }
 
-bool sort_by_len_hash(const struct compressed_block& lhs,
-		const struct compressed_block& rhs)
+bool sort_by_len_hash(const struct compressed_block &lhs,
+					  const struct compressed_block &rhs)
 {
 	if (lhs.length == rhs.length)
 		return lhs.hash < rhs.hash;
 	return lhs.length < rhs.length;
 }
 
-
-std::list<struct compressed_block> get_blocks(MMAPFile& f, Compressor*& c,
-		size_t& block_size)
+std::list<struct compressed_block> get_blocks(MMAPFile &f, Compressor *&c,
+											  size_t &block_size)
 {
-	const squashfs::super_block& sb = f.read<squashfs::super_block>();
+	const squashfs::super_block &sb = f.read<squashfs::super_block>();
 
 	if (sb.s_magic != squashfs::magic)
 		throw std::runtime_error(
-				"File is not a valid SquashFS image (no magic).");
+			"File is not a valid SquashFS image (no magic).");
 	if (sb.s_major != 4 || sb.s_minor != 0)
 		throw std::runtime_error("File is not SquashFS 4.0");
 
@@ -91,33 +92,34 @@ std::list<struct compressed_block> get_blocks(MMAPFile& f, Compressor*& c,
 
 	switch (sb.compression)
 	{
-		case squashfs::compression::lzo:
+	case squashfs::compression::lzo:
 #ifdef ENABLE_LZO
-			if (!c)
-				c = new LZOCompressor();
-			else if (typeid(*c) != typeid(LZOCompressor))
-				throw std::runtime_error("The two files use different compressors");
+		if (!c)
+			c = new LZOCompressor();
+		else if (typeid(*c) != typeid(LZOCompressor))
+			throw std::runtime_error("The two files use different compressors");
 #else
-			throw std::runtime_error("LZO compression support disabled at build time");
+		throw std::runtime_error("LZO compression support disabled at build time");
 #endif
-			break;
-		case squashfs::compression::lz4:
+		break;
+	case squashfs::compression::lz4:
 #ifdef ENABLE_LZ4
-			if (!c)
-				c = new LZ4Compressor();
-			else if (typeid(*c) != typeid(LZ4Compressor))
-				throw std::runtime_error("The two files use different compressors");
+		if (!c)
+			c = new LZ4Compressor();
+		else if (typeid(*c) != typeid(LZ4Compressor))
+			throw std::runtime_error("The two files use different compressors");
 #else
-			throw std::runtime_error("LZ4 compression support disabled at build time");
+		throw std::runtime_error("LZ4 compression support disabled at build time");
 #endif
-			break;
-		default:
-			throw std::runtime_error("Unsupported compression algorithm.");
+		break;
+	default:
+		throw std::runtime_error("Unsupported compression algorithm.");
 	}
 
 	MetadataReader coptsr(f, sizeof(sb), *c);
 	c->setup(sb.flags & squashfs::flags::compression_options
-			? &coptsr : 0);
+				 ? &coptsr
+				 : 0);
 	coptsr.block_num();
 
 	std::list<struct compressed_block>
@@ -130,14 +132,13 @@ std::list<struct compressed_block> get_blocks(MMAPFile& f, Compressor*& c,
 
 	for (uint32_t i = 0; i < sb.inodes; ++i)
 	{
-		union squashfs::inode::inode& in = ir.read();
+		union squashfs::inode::inode &in = ir.read();
 
-		if (in.as_base.inode_type == squashfs::inode::type::reg
-				|| in.as_base.inode_type == squashfs::inode::type::lreg)
+		if (in.as_base.inode_type == squashfs::inode::type::reg || in.as_base.inode_type == squashfs::inode::type::lreg)
 		{
-			uint32_t pos;
-			uint32_t block_count;
-			le32* block_list;
+			uint64_t pos;
+			uint64_t block_count;
+			le32 *block_list;
 
 			if (in.as_base.inode_type == squashfs::inode::type::reg)
 			{
@@ -157,8 +158,7 @@ std::list<struct compressed_block> get_blocks(MMAPFile& f, Compressor*& c,
 				if (block_list[j] & squashfs::block_size::uncompressed)
 				{
 					// seek over the uncompressed block
-					uint32_t len = (block_list[j]
-							& ~squashfs::block_size::uncompressed);
+					uint32_t len = (block_list[j] & ~squashfs::block_size::uncompressed);
 					assert(len != 0);
 					pos += len;
 				}
@@ -179,17 +179,17 @@ std::list<struct compressed_block> get_blocks(MMAPFile& f, Compressor*& c,
 
 	size_t block_num = ir.block_num();
 	std::cerr << "Read " << sb.inodes << " inodes in "
-		<< block_num << " blocks.\n";
+			  << block_num << " blocks.\n";
 
 	// record inode blocks
 
 	std::cerr << "Hashing " << block_num
-		<< " inode blocks..." << std::endl;
+			  << " inode blocks..." << std::endl;
 
 	MetadataBlockReader mir(f, sb.inode_table_start, *c);
 	for (size_t i = 0; i < block_num; ++i)
 	{
-		const void* data;
+		const void *data;
 		size_t pos;
 		size_t length;
 		bool compressed;
@@ -215,7 +215,7 @@ std::list<struct compressed_block> get_blocks(MMAPFile& f, Compressor*& c,
 
 	for (uint32_t i = 0; i < sb.fragments; ++i)
 	{
-		const struct squashfs::fragment_entry& fe = fr.read();
+		const struct squashfs::fragment_entry &fe = fr.read();
 		assert(fe.size != 0);
 
 		if (!(fe.size & squashfs::block_size::uncompressed))
@@ -230,17 +230,17 @@ std::list<struct compressed_block> get_blocks(MMAPFile& f, Compressor*& c,
 
 	block_num = fr.block_num();
 	std::cerr << "Read " << sb.fragments << " fragments in "
-		<< block_num << " blocks.\n";
+			  << block_num << " blocks.\n";
 
 	// record fragment table
 
 	std::cerr << "Hashing " << block_num
-		<< " fragment table blocks..." << std::endl;
+			  << " fragment table blocks..." << std::endl;
 
 	MetadataBlockReader mfr(f, fr.start_offset, *c);
 	for (size_t i = 0; i < block_num; ++i)
 	{
-		const void* data;
+		const void *data;
 		size_t pos;
 		size_t length;
 		bool compressed;
@@ -262,14 +262,14 @@ std::list<struct compressed_block> get_blocks(MMAPFile& f, Compressor*& c,
 	compressed_data_blocks.sort(sort_by_offset);
 
 	std::cerr << "Hashing " << compressed_data_blocks.size()
-		<< " data blocks..." << std::endl;
+			  << " data blocks..." << std::endl;
 	MMAPFile hf(f);
 
 	// record the checksums and perform initial deduplication
 	for (std::list<struct compressed_block>::iterator
-			i = compressed_data_blocks.begin(),
-			j = compressed_data_blocks.end();
-			i != compressed_data_blocks.end();)
+			 i = compressed_data_blocks.begin(),
+			 j = compressed_data_blocks.end();
+		 i != compressed_data_blocks.end();)
 	{
 		// duplicates will be adjacent after sorting
 		if ((*i).offset == ((*j).offset))
@@ -281,28 +281,28 @@ std::list<struct compressed_block> get_blocks(MMAPFile& f, Compressor*& c,
 
 		hf.seek((*i).offset, std::ios::beg);
 		(*i).hash = murmurhash3(hf.read_array<uint8_t>((*i).length),
-				(*i).length, 0);
+								(*i).length, 0);
 		j = i++;
 	}
 
 	compressed_data_blocks.splice(compressed_data_blocks.end(),
-			compressed_metadata_blocks);
+								  compressed_metadata_blocks);
 
 	std::cerr << "Total: " << compressed_data_blocks.size()
-		<< " compressed blocks." << std::endl;
+			  << " compressed blocks." << std::endl;
 
 	return compressed_data_blocks;
 }
 
-void write_unpacked_file(SparseFileWriter& outf, MMAPFile& inf,
-		std::list<struct compressed_block>& cb, Compressor& c,
-		size_t block_size)
+void write_unpacked_file(SparseFileWriter &outf, MMAPFile &inf,
+						 std::list<struct compressed_block> &cb, Compressor &c,
+						 size_t block_size)
 {
 	size_t prev_offset = 0;
 	inf.seek(0, std::ios::beg);
 
 	for (std::list<struct compressed_block>::iterator i = cb.begin();
-			i != cb.end(); ++i)
+		 i != cb.end(); ++i)
 	{
 		assert((*i).offset >= prev_offset);
 
@@ -319,25 +319,25 @@ void write_unpacked_file(SparseFileWriter& outf, MMAPFile& inf,
 
 	// write the last block
 	outf.write(inf.read_array<char>(inf.getlen() - prev_offset),
-			inf.getlen() - prev_offset);
+			   inf.getlen() - prev_offset);
 
-	char* buf = new char[block_size];
+	char *buf = new char[block_size];
 	try
 	{
 		for (std::list<struct compressed_block>::iterator i = cb.begin();
-				i != cb.end(); ++i)
+			 i != cb.end(); ++i)
 		{
 			size_t unc_length;
 
 			inf.seek((*i).offset, std::ios::beg);
 			unc_length = c.decompress(buf, inf.read_array<char>((*i).length),
-					(*i).length, block_size);
+									  (*i).length, block_size);
 
 			(*i).uncompressed_length = unc_length;
 			outf.write(buf, unc_length);
 		}
 	}
-	catch (std::exception& e)
+	catch (std::exception &e)
 	{
 		delete[] buf;
 		throw;
@@ -345,8 +345,8 @@ void write_unpacked_file(SparseFileWriter& outf, MMAPFile& inf,
 	delete[] buf;
 }
 
-void write_block_list(SparseFileWriter& outf, sqdelta_header h,
-		std::list<struct compressed_block>& cb, bool at_end = true)
+void write_block_list(SparseFileWriter &outf, sqdelta_header h,
+					  std::list<struct compressed_block> &cb, bool at_end = true)
 {
 	// store the block count in header
 	h.block_count = htonl(cb.size());
@@ -355,7 +355,7 @@ void write_block_list(SparseFileWriter& outf, sqdelta_header h,
 		outf.write<struct sqdelta_header>(h);
 
 	for (std::list<struct compressed_block>::iterator i = cb.begin();
-			i != cb.end(); ++i)
+		 i != cb.end(); ++i)
 	{
 		struct serialized_compressed_block b;
 
@@ -370,7 +370,7 @@ void write_block_list(SparseFileWriter& outf, sqdelta_header h,
 		outf.write<struct sqdelta_header>(h);
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
 	if (argc < 4)
 	{
@@ -378,9 +378,9 @@ int main(int argc, char* argv[])
 		return 1;
 	}
 
-	const char* source_file = argv[1];
-	const char* target_file = argv[2];
-	const char* patch_file = argv[3];
+	const char *source_file = argv[1];
+	const char *target_file = argv[2];
+	const char *patch_file = argv[3];
 
 	try
 	{
@@ -389,7 +389,7 @@ int main(int argc, char* argv[])
 		std::list<struct compressed_block> source_blocks;
 		std::list<struct compressed_block> target_blocks;
 
-		Compressor* c = 0;
+		Compressor *c = 0;
 		size_t block_size = 0;
 
 		try
@@ -398,19 +398,19 @@ int main(int argc, char* argv[])
 			std::cerr << "Source: " << source_file << "\n";
 			source_blocks = get_blocks(source_f, c, block_size);
 		}
-		catch (IOError& e)
+		catch (IOError &e)
 		{
 			std::cerr << "Program terminated abnormally:\n\t"
-				<< e.what() << "\n\tat file: " << source_file
-				<< "\n\terrno: " << strerror(e.errno_val) << "\n";
+					  << e.what() << "\n\tat file: " << source_file
+					  << "\n\terrno: " << strerror(e.errno_val) << "\n";
 			if (c)
 				delete c;
 			return 1;
 		}
-		catch (std::exception& e)
+		catch (std::exception &e)
 		{
 			std::cerr << "Program terminated abnormally:\n\t"
-				<< e.what() << "\n\tat file: " << source_file << "\n";
+					  << e.what() << "\n\tat file: " << source_file << "\n";
 			if (c)
 				delete c;
 			return 1;
@@ -424,18 +424,18 @@ int main(int argc, char* argv[])
 			std::cerr << "Target: " << target_file << "\n";
 			target_blocks = get_blocks(target_f, c, block_size);
 		}
-		catch (IOError& e)
+		catch (IOError &e)
 		{
 			std::cerr << "Program terminated abnormally:\n\t"
-				<< e.what() << "\n\tat file: " << source_file
-				<< "\n\terrno: " << strerror(e.errno_val) << "\n";
+					  << e.what() << "\n\tat file: " << source_file
+					  << "\n\terrno: " << strerror(e.errno_val) << "\n";
 			delete c;
 			return 1;
 		}
-		catch (std::exception& e)
+		catch (std::exception &e)
 		{
 			std::cerr << "Program terminated abnormally:\n\t"
-				<< e.what() << "\n\tat file: " << source_file << "\n";
+					  << e.what() << "\n\tat file: " << source_file << "\n";
 			delete c;
 			return 1;
 		}
@@ -446,9 +446,9 @@ int main(int argc, char* argv[])
 		target_blocks.sort(sort_by_len_hash);
 
 		for (std::list<struct compressed_block>::iterator
-				i = source_blocks.begin(),
-				j = target_blocks.begin();
-				i != source_blocks.end() && j != target_blocks.end();)
+				 i = source_blocks.begin(),
+				 j = target_blocks.begin();
+			 i != source_blocks.end() && j != target_blocks.end();)
 		{
 			// seek until we find duplicates
 			if ((*i).length < (*j).length)
@@ -463,16 +463,13 @@ int main(int argc, char* argv[])
 			{
 				// found a match, remove the blocks then
 				std::list<struct compressed_block>::iterator
-					i_st = i, j_st = j;
+					i_st = i,
+					j_st = j;
 
 				// remove consecutive duplicates as well
-				while (i != source_blocks.end()
-						&& (*i).length == (*i_st).length
-						&& (*i).hash == (*i_st).hash)
+				while (i != source_blocks.end() && (*i).length == (*i_st).length && (*i).hash == (*i_st).hash)
 					++i;
-				while (j != target_blocks.end()
-						&& (*j).length == (*j_st).length
-						&& (*j).hash == (*j_st).hash)
+				while (j != target_blocks.end() && (*j).length == (*j_st).length && (*j).hash == (*j_st).hash)
 					++j;
 
 				source_blocks.erase(i_st, i);
@@ -481,8 +478,8 @@ int main(int argc, char* argv[])
 		}
 
 		std::cerr << "Unique blocks found: "
-			<< source_blocks.size() << " in source and "
-			<< target_blocks.size() << " in target.\n";
+				  << source_blocks.size() << " in source and "
+				  << target_blocks.size() << " in target.\n";
 
 		// now we need to write the expanded files
 
@@ -493,7 +490,7 @@ int main(int argc, char* argv[])
 		SparseFileWriter patch_out;
 		patch_out.open(patch_file);
 
-		const char* tmpdir = getenv("TMPDIR");
+		const char *tmpdir = getenv("TMPDIR");
 #ifdef _P_tmpdir
 		if (!tmpdir)
 			tmpdir = P_tmpdir;
@@ -504,7 +501,8 @@ int main(int argc, char* argv[])
 		if (chdir(tmpdir) == -1)
 		{
 			std::cerr << "Unable to chdir() into temporary directory\n"
-				"\tDirectory: " << tmpdir << "\n";
+						 "\tDirectory: "
+					  << tmpdir << "\n";
 			delete c;
 			return 1;
 		}
@@ -522,21 +520,21 @@ int main(int argc, char* argv[])
 			c->reset();
 			source_temp.open(source_f.getlen());
 			write_unpacked_file(source_temp, source_f, source_blocks, *c,
-					block_size);
+								block_size);
 			write_block_list(source_temp, dh, source_blocks);
 		}
-		catch (IOError& e)
+		catch (IOError &e)
 		{
 			std::cerr << "Program terminated abnormally:\n\t"
-				<< e.what() << "\n\tat temporary file for source"
-				<< "\n\terrno: " << strerror(e.errno_val) << "\n";
+					  << e.what() << "\n\tat temporary file for source"
+					  << "\n\terrno: " << strerror(e.errno_val) << "\n";
 			delete c;
 			return 1;
 		}
-		catch (std::exception& e)
+		catch (std::exception &e)
 		{
 			std::cerr << "Program terminated abnormally:\n\t"
-				<< e.what() << "\n\tat temporary file for source\n";
+					  << e.what() << "\n\tat temporary file for source\n";
 			delete c;
 			return 1;
 		}
@@ -548,21 +546,21 @@ int main(int argc, char* argv[])
 			c->reset();
 			target_temp.open(target_f.getlen());
 			write_unpacked_file(target_temp, target_f, target_blocks, *c,
-					block_size);
+								block_size);
 			write_block_list(target_temp, dh, target_blocks);
 		}
-		catch (IOError& e)
+		catch (IOError &e)
 		{
 			std::cerr << "Program terminated abnormally:\n\t"
-				<< e.what() << "\n\tat temporary file for target"
-				<< "\n\terrno: " << strerror(e.errno_val) << "\n";
+					  << e.what() << "\n\tat temporary file for target"
+					  << "\n\terrno: " << strerror(e.errno_val) << "\n";
 			delete c;
 			return 1;
 		}
-		catch (std::exception& e)
+		catch (std::exception &e)
 		{
 			std::cerr << "Program terminated abnormally:\n\t"
-				<< e.what() << "\n\tat temporary file for target\n";
+					  << e.what() << "\n\tat temporary file for target\n";
 			delete c;
 			return 1;
 		}
@@ -587,15 +585,15 @@ int main(int argc, char* argv[])
 					throw IOError("Unable to override stdout via dup2()", errno);
 
 				if (execlp("xdelta3",
-						"xdelta3", "-v", "-9", "-S", "djw",
-						"-s", source_temp.name(), target_temp.name(),
-						static_cast<const char*>(0)) == -1)
+						   "xdelta3", "-v", "-9", "-S", "djw",
+						   "-s", source_temp.name(), target_temp.name(),
+						   static_cast<const char *>(0)) == -1)
 					throw IOError("execlp() failed", errno);
 			}
-			catch (IOError& e)
+			catch (IOError &e)
 			{
 				std::cerr << "Error occured in child process:\n\t"
-					<< e.what() << "\n\terrno: " << strerror(e.errno_val) << "\n";
+						  << e.what() << "\n\terrno: " << strerror(e.errno_val) << "\n";
 				return 1;
 			}
 		}
@@ -608,7 +606,8 @@ int main(int argc, char* argv[])
 			if (WEXITSTATUS(status) != 0)
 			{
 				std::cerr << "Child process terminate with error status\n"
-					"\treturn code: " << WEXITSTATUS(status) << "\n";
+							 "\treturn code: "
+						  << WEXITSTATUS(status) << "\n";
 				return 1;
 			}
 		}
@@ -617,10 +616,10 @@ int main(int argc, char* argv[])
 		source_temp.close();
 		patch_out.close();
 	}
-	catch (IOError& e)
+	catch (IOError &e)
 	{
 		std::cerr << "Error occured:\n\t"
-			<< e.what() << "\n\terrno: " << strerror(e.errno_val) << "\n";
+				  << e.what() << "\n\terrno: " << strerror(e.errno_val) << "\n";
 		return 1;
 	}
 

--- a/src/squashdelta.cxx
+++ b/src/squashdelta.cxx
@@ -33,6 +33,7 @@ extern "C"
 
 struct compressed_block
 {
+	// Host endianness
 	uint64_t offset;
 	uint32_t length;
 	uint32_t uncompressed_length;
@@ -42,6 +43,7 @@ struct compressed_block
 #pragma pack(push, 1)
 struct serialized_compressed_block
 {
+	// Shall be big-endian
 	uint64_t offset;
 	uint32_t length;
 	uint32_t uncompressed_length;

--- a/src/squashdelta.cxx
+++ b/src/squashdelta.cxx
@@ -33,9 +33,9 @@ extern "C"
 
 struct compressed_block
 {
-	size_t offset;
-	size_t length;
-	size_t uncompressed_length;
+	uint64_t offset;
+	uint32_t length;
+	uint32_t uncompressed_length;
 	uint32_t hash;
 };
 

--- a/src/squashdelta.cxx
+++ b/src/squashdelta.cxx
@@ -169,7 +169,7 @@ std::list<struct compressed_block> get_blocks(MMAPFile &f, Compressor *&c,
 				block_list = in.as_lreg.block_list();
 			}
 
-			for (uint32_t j = 0; j < block_count; ++j)
+			for (uint64_t j = 0; j < block_count; ++j)
 			{
 				if (block_list[j] & squashfs::block_size::uncompressed)
 				{

--- a/src/squashdelta.cxx
+++ b/src/squashdelta.cxx
@@ -56,7 +56,23 @@ struct sqdelta_header
 };
 #pragma pack(pop)
 
-#define htonl(val) val
+#ifndef htonll
+uint64_t htonll(uint64_t hostlonglong)
+{
+	// Check system endianness
+	static const int one = 1;
+	if (*(const char *)&one == 1)
+	{ // Little endian
+		// Perform byte swap
+		return ((uint64_t)htonl((uint32_t)(hostlonglong & 0xFFFFFFFF)) << 32) | htonl((uint32_t)(hostlonglong >> 32));
+	}
+	else
+	{
+		// Big endian - no need to swap bytes
+		return hostlonglong;
+	}
+}
+#endif
 
 const uint32_t sqdelta_magic = 0x5371ceb4;
 
@@ -359,7 +375,7 @@ void write_block_list(SparseFileWriter &outf, sqdelta_header h,
 	{
 		struct serialized_compressed_block b;
 
-		b.offset = htonl((*i).offset);
+		b.offset = htonll((*i).offset);
 		b.length = htonl((*i).length);
 		b.uncompressed_length = htonl((*i).uncompressed_length);
 

--- a/src/squashfs.cxx
+++ b/src/squashfs.cxx
@@ -43,10 +43,10 @@ le32* squashfs::inode::reg::block_list()
 	return static_cast<le32*>(voidp);
 }
 
-uint64_t squashfs::inode::reg::block_count(uint32_t block_size,
+uint32_t squashfs::inode::reg::block_count(uint32_t block_size,
 		uint16_t block_log)
 {
-	uint64_t blocks = file_size;
+	uint32_t blocks = file_size;
 
 	// if fragments were not used, round up the last block
 	if (fragment == squashfs::invalid_frag)
@@ -61,7 +61,7 @@ uint64_t squashfs::inode::reg::block_count(uint32_t block_size,
 size_t squashfs::inode::reg::inode_size(uint32_t block_size,
 		uint16_t block_log)
 {
-	uint64_t blocks = block_count(block_size, block_log);
+	uint32_t blocks = block_count(block_size, block_log);
 
 	return sizeof(*this) + blocks * sizeof(le32);
 }

--- a/src/squashfs.cxx
+++ b/src/squashfs.cxx
@@ -147,9 +147,10 @@ void MetadataBlockReader::read_input_block(const void** data,
 MetadataReader::MetadataReader(const MMAPFile& new_file,
 		size_t offset, Compressor& c)
 	: f(new_file, offset, c),
-	bufp(buf), buf_filled(0), _block_num(0)
+	buf_filled(0), _block_num(0)
 {
 	buf = new char[buf_size];
+	bufp = buf;
 }
 
 MetadataReader::~MetadataReader()

--- a/src/squashfs.cxx
+++ b/src/squashfs.cxx
@@ -43,10 +43,10 @@ le32* squashfs::inode::reg::block_list()
 	return static_cast<le32*>(voidp);
 }
 
-uint32_t squashfs::inode::reg::block_count(uint32_t block_size,
+uint64_t squashfs::inode::reg::block_count(uint32_t block_size,
 		uint16_t block_log)
 {
-	uint32_t blocks = file_size;
+	uint64_t blocks = file_size;
 
 	// if fragments were not used, round up the last block
 	if (fragment == squashfs::invalid_frag)
@@ -61,7 +61,7 @@ uint32_t squashfs::inode::reg::block_count(uint32_t block_size,
 size_t squashfs::inode::reg::inode_size(uint32_t block_size,
 		uint16_t block_log)
 {
-	uint32_t blocks = block_count(block_size, block_log);
+	uint64_t blocks = block_count(block_size, block_log);
 
 	return sizeof(*this) + blocks * sizeof(le32);
 }
@@ -78,10 +78,10 @@ struct squashfs::dir_index* squashfs::inode::ldir::index()
 	return static_cast<struct dir_index*>(voidp);
 }
 
-uint32_t squashfs::inode::lreg::block_count(uint32_t block_size,
+uint64_t squashfs::inode::lreg::block_count(uint32_t block_size,
 		uint16_t block_log)
 {
-	uint32_t blocks = file_size;
+	uint64_t blocks = file_size;
 
 	// if fragments were not used, round up the last block
 	if (fragment == squashfs::invalid_frag)

--- a/src/squashfs.cxx
+++ b/src/squashfs.cxx
@@ -149,6 +149,12 @@ MetadataReader::MetadataReader(const MMAPFile& new_file,
 	: f(new_file, offset, c),
 	bufp(buf), buf_filled(0), _block_num(0)
 {
+	buf = new char[buf_size];
+}
+
+MetadataReader::~MetadataReader()
+{
+	delete[] buf;
 }
 
 void MetadataReader::poll_data()

--- a/src/squashfs.cxx
+++ b/src/squashfs.cxx
@@ -96,7 +96,7 @@ uint64_t squashfs::inode::lreg::block_count(uint32_t block_size,
 size_t squashfs::inode::lreg::inode_size(uint32_t block_size,
 		uint16_t block_log)
 {
-	uint32_t blocks = block_count(block_size, block_log);
+	uint64_t blocks = block_count(block_size, block_log);
 
 	return sizeof(*this) + blocks * sizeof(le32);
 }

--- a/src/squashfs.hxx
+++ b/src/squashfs.hxx
@@ -207,8 +207,9 @@ namespace squashfs
 			size_t inode_size(uint32_t block_size, uint16_t block_log);
 			static constexpr size_t max_possible_inode_size(uint_fast64_t max_file_size) {
 				// Max possible length of array of block sizes happens with largest possible
-				// file (2^64) and smallest possible block size (2^12 = 4096).
-                return sizeof(lreg) + max_file_size / 4096 * sizeof(le32);
+				// file (2^64) and smallest possible block size (2^12).
+				// max_file_size / 2^12 * sizeof(le32) == max_file_size >> 10
+                return sizeof(lreg) + (max_file_size >> 10);
             }
 		};
 

--- a/src/squashfs.hxx
+++ b/src/squashfs.hxx
@@ -171,9 +171,9 @@ namespace squashfs
 
 			size_t inode_size();
 			static constexpr size_t max_possible_inode_size(uint_fast32_t max_symlink_target_size) {
-                // Max possible symlink happens with longest possible symlink target (2^32)
-                return sizeof(symlink) + max_symlink_target_size;
-            }
+				// Max possible symlink happens with longest possible symlink target (2^32)
+				return sizeof(symlink) + max_symlink_target_size;
+			}
 		};
 
 		struct reg : public base
@@ -209,8 +209,8 @@ namespace squashfs
 				// Max possible length of array of block sizes happens with largest possible
 				// file (2^64) and smallest possible block size (2^12).
 				// max_file_size / 2^12 * sizeof(le32) == max_file_size >> 10
-                return sizeof(lreg) + (max_file_size >> 10);
-            }
+				return sizeof(lreg) + (max_file_size >> 10);
+			}
 		};
 
 		struct dir : public base

--- a/src/squashfs.hxx
+++ b/src/squashfs.hxx
@@ -277,6 +277,11 @@ class MetadataReader
 {
 	MetadataBlockReader f;
 
+	// Supporting the max possible file in squashfs (16 exbibytes) leads to an impossibly large
+	// inode that we'd have to load (16 pebibytes), so we have to pick an arbitrary limit that's
+	// more reasonable.
+	// This doesn't consume physical memory (on Linux) unless that part of the buffer is actually
+	// written to. https://stackoverflow.com/questions/864416/are-some-allocators-lazy
 	static constexpr size_t max_supported_file_size = 1ull << 40; // 1 TiB -> 1 GiB buffer (2^30)
 
 	static constexpr size_t buf_size = squashfs::inode::lreg::max_possible_inode_size(max_supported_file_size);

--- a/src/squashfs.hxx
+++ b/src/squashfs.hxx
@@ -281,9 +281,11 @@ class MetadataReader
 	// Supporting the max possible file in squashfs (16 exbibytes) leads to an impossibly large
 	// inode that we'd have to load (16 pebibytes), so we have to pick an arbitrary limit that's
 	// more reasonable.
+	// We'll arbitrarily pick 1 TiB (2^40) as the max supported file size. This leads to a max inode
+	// size (and therefore buffer size) of 1 GiB (2^30) plus a few extra bytes.
 	// This doesn't consume physical memory (on Linux) unless that part of the buffer is actually
 	// written to. https://stackoverflow.com/questions/864416/are-some-allocators-lazy
-	static constexpr size_t max_supported_file_size = 1ull << 40; // 1 TiB -> 1 GiB buffer (2^30)
+	static constexpr size_t max_supported_file_size = 1ull << 40;
 
 	static constexpr size_t buf_size = squashfs::inode::lreg::max_possible_inode_size(max_supported_file_size);
 	char* buf;

--- a/src/squashfs.hxx
+++ b/src/squashfs.hxx
@@ -277,10 +277,10 @@ class MetadataReader
 {
 	MetadataBlockReader f;
 
-	static constexpr size_t max_supported_file_size = 0x10000000000; // 1 TiB
-        
-	static const size_t buf_size = squashfs::inode::lreg::max_possible_inode_size(max_supported_file_size);
-	char buf[buf_size];
+	static constexpr size_t max_supported_file_size = 1ull << 40; // 1 TiB -> 1 GiB buffer (2^30)
+
+	static constexpr size_t buf_size = squashfs::inode::lreg::max_possible_inode_size(max_supported_file_size);
+	char* buf;
 	char* bufp;
 	size_t buf_filled;
 	size_t _block_num;
@@ -290,6 +290,7 @@ class MetadataReader
 public:
 	MetadataReader(const MMAPFile& new_file,
 			size_t offset, Compressor& c);
+	~MetadataReader();
 
 	template <class T>
 	const T& read();

--- a/src/squashfs.hxx
+++ b/src/squashfs.hxx
@@ -181,7 +181,7 @@ namespace squashfs
 			//le32 block_list[0];
 			le32* block_list();
 
-			uint32_t block_count(uint32_t block_size, uint16_t block_log);
+			uint64_t block_count(uint32_t block_size, uint16_t block_log);
 			size_t inode_size(uint32_t block_size, uint16_t block_log);
 		};
 
@@ -198,7 +198,7 @@ namespace squashfs
 			//le32 block_list[0];
 			le32* block_list();
 
-			uint32_t block_count(uint32_t block_size, uint16_t block_log);
+			uint64_t block_count(uint32_t block_size, uint16_t block_log);
 			size_t inode_size(uint32_t block_size, uint16_t block_log);
 		};
 

--- a/src/squashfs.hxx
+++ b/src/squashfs.hxx
@@ -181,7 +181,7 @@ namespace squashfs
 			//le32 block_list[0];
 			le32* block_list();
 
-			uint64_t block_count(uint32_t block_size, uint16_t block_log);
+			uint32_t block_count(uint32_t block_size, uint16_t block_log);
 			size_t inode_size(uint32_t block_size, uint16_t block_log);
 		};
 

--- a/src/util.hxx
+++ b/src/util.hxx
@@ -41,6 +41,16 @@ inline uint32_t le_to_host(uint32_t n) { return le32toh(n); }
 template <>
 inline uint64_t le_to_host(uint64_t n) { return le64toh(n); }
 
+// converters from host to LE
+template <class T>
+inline T host_to_le(T n);
+template <>
+inline uint16_t host_to_le(uint16_t n) { return htole16(n); }
+template <>
+inline uint32_t host_to_le(uint32_t n) { return htole32(n); }
+template <>
+inline uint64_t host_to_le(uint64_t n) { return htole64(n); }
+
 // magic auto-conversion types
 template <class T>
 class LittleEndian
@@ -51,6 +61,11 @@ public:
 	inline operator T() const
 	{
 		return le_to_host<T>(data);
+	}
+
+	inline void operator=(const T& value)
+	{
+		data = host_to_le<T>(value);
 	}
 };
 


### PR DESCRIPTION
Linter got a little aggressive - core change is ensuring offset calculations are done using `uint64_t` size objects.

Tested (jointly with https://github.com/braincorp/squashmerge/pull/4):
- [x] Backwards compatibility with unchanged squashmerge: No, it doesn't recognize the file.
- [x] squashfs target containing a single large file (33 GiB): Pass
- [x] squashfs target containing a max-length symlink (255 chars possible on ext4): Pass
- [x] ~~squashfs target containing a directory with many files:~~ No need. `/var/lib/dpkg/info` already has 5374 files in it.